### PR TITLE
require 'thread' under ruby 1.8 so that mutex is defined

### DIFF
--- a/lib/gene_pool.rb
+++ b/lib/gene_pool.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'thread' if RUBY_VERSION < '1.9'
 
 # Generic connection pool class
 class GenePool


### PR DESCRIPTION
You need to require 'thread' under ruby 1.8 to get Mutex.
