### PR TITLE
close_connection(): close method is correctly invoked when ...

### DIFF
--- a/gene_pool.gemspec
+++ b/gene_pool.gemspec
@@ -7,6 +7,6 @@ Gem::Specification.new do |s|
   s.homepage      = 'http://github.com/bpardee/gene_pool'
   s.files         = Dir["{examples,lib}/**/*"] + %w(LICENSE.txt Rakefile Gemfile History.md README.md)
   s.test_files    = ["test/gene_pool_test.rb"]
-  s.version       = '1.3.0'
+  s.version       = '1.3.1'
   s.require_paths = ["lib"]
 end

--- a/lib/gene_pool.rb
+++ b/lib/gene_pool.rb
@@ -98,7 +98,7 @@ class GenePool
     elsif @idle_timeout && (Time.now - connection._last_used) >= @idle_timeout
       connection = renew(connection)
     end
-    
+
     @logger.debug {"#{@name}: Checkout connection #{connection}(#{connection.object_id}) self=#{self}"}
     return connection
   end
@@ -117,7 +117,7 @@ class GenePool
     end
     @logger.debug {"#{@name}: Checkin connection #{connection}(#{connection.object_id}) self=#{self}"}
   end
-  
+
   # Create a scope for checking out a connection
   # The client should handle cleanup on exception which should be something similar to the following:
   #   rescue Exception => e
@@ -218,7 +218,7 @@ class GenePool
     @logger.debug {"#{@name}: Renewed connection old=#{old_connection.object_id} new=#{new_connection}(#{new_connection.object_id})"}
     return new_connection
   end
-  
+
   # Perform the given block for each connection.  Note that close should be used for safely closing all connections
   # This should probably only ever be used to allow interrupt of a connection that is checked out?
   def each
@@ -270,7 +270,7 @@ class GenePool
     # Thread is used as a reserved_connection_placeholder so don't close the connection if it's actually a thread
     return if connection.kind_of?(Thread)
     if @close_proc.kind_of?(Symbol)
-      connection.send(@close_proc)
+      connection.__send__(@close_proc)
     else
       @close_proc.call(connection)
     end

--- a/test/gene_pool_test.rb
+++ b/test/gene_pool_test.rb
@@ -19,7 +19,7 @@ class DummyConnection
     @closed = false
     @other_closed = false
   end
-  
+
   def to_s
     @count.to_s
   end
@@ -43,8 +43,12 @@ class DummyConnection
   def other_closed?
     @other_closed
   end
+
+  def send(msg, flags)
+    # override Object#send ( to simulate e.g. BasicSocket#send )
+  end
 end
-    
+
 
 class GenePoolTest < Test::Unit::TestCase
 
@@ -60,7 +64,7 @@ class GenePoolTest < Test::Unit::TestCase
       assert                   @gene_pool.logger
     end
   end
-  
+
   context '' do
     setup do
       #@stringio = StringIO.new
@@ -101,7 +105,7 @@ class GenePoolTest < Test::Unit::TestCase
         assert_equal 0, @gene_pool.checked_out.size
       end
     end
-  
+
     should 'create 2 connections' do
       conn1 = @gene_pool.checkout
       (1..3).each do |i|
@@ -120,7 +124,7 @@ class GenePoolTest < Test::Unit::TestCase
       @gene_pool.checkin(conn1)
       assert_equal 0, @gene_pool.checked_out.size
     end
-  
+
     should 'be able to reset multiple times' do
       @gene_pool.with_connection do |conn1|
         conn2 = @gene_pool.renew(conn1)
@@ -134,7 +138,7 @@ class GenePoolTest < Test::Unit::TestCase
       assert_equal 1, @gene_pool.connections.size
       assert_equal 0, @gene_pool.checked_out.size
     end
-  
+
     should 'be able to remove connection' do
       @gene_pool.with_connection do |conn|
         @gene_pool.remove(conn)
@@ -144,7 +148,7 @@ class GenePoolTest < Test::Unit::TestCase
       assert_equal 0, @gene_pool.connections.size
       assert_equal 0, @gene_pool.checked_out.size
     end
-  
+
     should 'be able to remove multiple connections' do
       @gene_pool.with_connection do |conn1|
         @gene_pool.with_connection do |conn2|
@@ -165,7 +169,7 @@ class GenePoolTest < Test::Unit::TestCase
       assert_equal 1, @gene_pool.connections.size
       assert_equal 0, @gene_pool.checked_out.size
     end
-  
+
     should 'handle aborted connection' do
       @gene_pool.with_connection do |conn1|
         @sleep = 2
@@ -188,7 +192,7 @@ class GenePoolTest < Test::Unit::TestCase
         end
       end
     end
-  
+
     should 'not allow more than pool_size connections' do
       conns = []
       pool_size = @gene_pool.pool_size
@@ -367,7 +371,6 @@ class GenePoolTest < Test::Unit::TestCase
       assert !conn.closed?
       assert conn.other_closed?
     end
-
 
     should 'allow nil so it does not execute a close' do
       @gene_pool = GenePool.new(:close_proc => nil) do


### PR DESCRIPTION
`close_connection()`: `close` method is correctly invoked when `@close_proc` is `Symbol` and `connection` overrides `send()`.
