### PR TITLE
Throttle request rate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ end
 group :test do
   gem 'minitest', "~> 4.0"
   gem 'shoulda'
+  gem 'test-unit'
 end

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Generic pooling library for connection pools.
         # Raise Timeout::Error if waiting for a connection more than 3 seconds.
         @@gene_pool = GenePool.new(:name         => 'MyClient',
                                    :pool_size    => 10,
+                                   :throttle     => 10,
                                    :timeout      => 3,
                                    :warn_timeout => 0.25,
                                    :idle_timeout => 10,

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Generic pooling library for connection pools.
         # Raise Timeout::Error if waiting for a connection more than 3 seconds.
         @@gene_pool = GenePool.new(:name         => 'MyClient',
                                    :pool_size    => 10,
-                                   :throttle     => 10,
                                    :timeout      => 3,
                                    :warn_timeout => 0.25,
                                    :idle_timeout => 10,

--- a/lib/gene_pool.rb
+++ b/lib/gene_pool.rb
@@ -84,7 +84,7 @@ class GenePool
             if @throttle
               allowed = (1.0 / @throttle)
               actual  = Time.now - connection._last_used
-              @condition.wait(allowed - actual) if actual < allowed
+              sleep allowed - actual if actual < allowed
             end
 
             @checked_out << connection unless connection.nil?

--- a/test/gene_pool_test.rb
+++ b/test/gene_pool_test.rb
@@ -226,7 +226,7 @@ class GenePoolTest < Test::Unit::TestCase
         @gene_pool.with_connection_auto_remove do |conn|
           next unless conn._last_used
           delta = Time.now - conn._last_used
-          assert delta > interval, "Request rate violation"
+          assert delta >= interval, "Request rate violation"
         end
       end
 


### PR DESCRIPTION
Added ability to throttle request rate through each connection. If throttle is set to 10 requests per second and pool size is set to 10 connections then 100 requests per second would be allowed.

Also added #checked_out to give visibility into pool utilization from application space.